### PR TITLE
dockerize with docker-compose and angular dev server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+node_modules/
+.gitignore
+README.md
+.env.example
+dist/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+NODE_ENV=development

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ Thumbs.db
 package-lock.json
 
 .env
+.env.production

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ testem.log
 Thumbs.db
 
 package-lock.json
+
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:lts-alpine
+
+RUN apk update && apk upgrade
+
+WORKDIR /usr/src/app
+
+ENV NODE_ENV production
+ENV PATH /app/node_modules/.bin:$PATH
+
+COPY package*.json ./
+RUN npm install -g npm@latest
+RUN npm install
+RUN npm install -g @angular/cli
+
+COPY . ./
+
+EXPOSE 4200
+
+CMD ng serve --host 0.0.0.0
+
+# RUN ng build --prod
+
+# FROM nginx:latest-alpine
+
+# EXPOSE 80
+
+# COPY nginx.conf /etc/nginx/nginx.conf
+
+# COPY --from=build /usr/src/app/dist/FileBox /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@
     <img alt="GitHub issues" src="https://img.shields.io/github/issues/krissemicolon/FileBox?style=flat-square&labelColor=333132&color=333132">
 </h1> </br>
 
+## Docker
+
+If you want to use plain docker, you can build the docker image with `docker built -t filebox .`
+and run a container with `docker run -d -p 4200:4200 filebox:latest`.
+This will run a container of filebox in detached mode, so it keeps running after you close the Terminal. To remove the container, run `docker kill <container_name>`. You can find the container name by running `docker ps | grep filebox | awk 'OFS="\t" {print $11}'`, if you haven't specified your own container name.
+
+### Docker Compose
+
+You can also use the provided docker-compose.yml to simplify the dockerization process. Just run `docker-compose up -d`, and you're done.
+This will also run in detached mode, but you can kill it the same way like a normal container.
+
 ## Development server
 
 Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.

--- a/angular.json
+++ b/angular.json
@@ -26,13 +26,8 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
             "aot": true,
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.scss"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.scss"],
             "scripts": []
           },
           "configurations": {
@@ -53,8 +48,8 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kb",
-                  "maximumError": "1mb"
+                  "maximumWarning": "2mb",
+                  "maximumError": "4mb"
                 },
                 {
                   "type": "anyComponentStyle",
@@ -89,13 +84,8 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.scss"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.scss"],
             "scripts": []
           }
         },
@@ -107,9 +97,7 @@
               "tsconfig.spec.json",
               "e2e/tsconfig.json"
             ],
-            "exclude": [
-              "**/node_modules/**"
-            ]
+            "exclude": ["**/node_modules/**"]
           }
         },
         "e2e": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.7"
+
+services:
+  filebox:
+    build: .
+    container_name: filebox
+    env_file:
+      - .env.production
+    ports:
+      # - "8080:80"
+      - "4200:4200"
+    volumes:
+      - ".:/usr/src/app"
+    restart: unless-stopped


### PR DESCRIPTION
# Dockerization

I added a Dockerfile to build the image and a docker-compose file to simplify deployment. For now, it uses the angular dev server, you may want to switch to nginx or something similar in the future.

## docker-compose

To deploy with the included docker-compose.yml, run `docker-compose up -d`. Using docker-compose is the way I would recommend. To use docker-compose, you need to install it using pip or a package manager, like portage.


## Note

I increased the initial budget for the builder in the `angular.json` file, because you may run into an error when trying to use `ng build --prod`. Undoing this wont affect the docker image.
